### PR TITLE
Elements after 5th are not in Fibonacci sequence

### DIFF
--- a/Fibonacci-Series.asm
+++ b/Fibonacci-Series.asm
@@ -18,7 +18,6 @@ MOV BX,01H       ; Default No
 
 ;Fibonacci Part
 L1:ADD AX,BX
-DAA              ; Used to Present the value in Decimal Form
 MOV [SI],AX
 MOV AX,BX
 MOV BX,[SI]


### PR DESCRIPTION
If we execute the given Fibonacci program it gives wrong output 5th value onward. By removing DAA(Decimal Adjust after Addition) we get the right output.